### PR TITLE
feat: Add valid event names for assistant guide click tracks

### DIFF
--- a/reload_app/app.py
+++ b/reload_app/app.py
@@ -18,7 +18,8 @@ NULLABLE_FIELDS = (
     'url', 'referrer', 'title', 'path', 'search',
     'anonymous_id', 'user_id',
 )
-VALID_EVENT_NAMES = ('click', 'assistant.search')
+VALID_EVENT_NAMES = ('click', 'assistant.search', 'assistant.guide_cued', 'assistant.guide_opened',
+    'assistant.guide_dismissed', 'assistant.guide_next', 'assistant.guide_closed')
 
 # Prefix event names to avoid collisions with events from Sentry backend.
 EVENT_NAME_TEMPLATE = 'reload.%s'


### PR DESCRIPTION
Linked to this GH [PR](https://github.com/getsentry/sentry/pull/7764) that introduces click tracking for assistant guides.