### PR TITLE
feat:Extra type check

### DIFF
--- a/reload_app/app.py
+++ b/reload_app/app.py
@@ -227,8 +227,9 @@ class App(Router):
             except ValueError:
                 client.captureException()
                 return Response('bad request maybe check field type\n', status=400)
+
             if type(data[field]) != typ:
-                return Response('bad request maybe check field type\n', status=400)
+                return client.captureMessage('field type does not match whitelisted type', level='warning')
             clean_data[field] = data[field]
 
         # Conforms to super-big-data.analytics.events schema.

--- a/reload_app/app.py
+++ b/reload_app/app.py
@@ -227,6 +227,8 @@ class App(Router):
             except ValueError:
                 client.captureException()
                 return Response('bad request maybe check field type\n', status=400)
+            if type(data[field]) != typ:
+                return Response('bad request maybe check field type\n', status=400)
             clean_data[field] = data[field]
 
         # Conforms to super-big-data.analytics.events schema.

--- a/reload_app/app.py
+++ b/reload_app/app.py
@@ -229,8 +229,14 @@ class App(Router):
                 return Response('bad request maybe check field type\n', status=400)
 
             if type(data[field]) != typ:
-                client.captureMessage('field type does not match whitelisted type', level='warning')
-
+                client.captureMessage('field type does not match whitelisted type',
+                    level='warning',
+                    extra={'event_name': data.get('event_name'),
+                            'field': field,
+                            'type_expected': typ,
+                            'type_received': type(data[field])
+                        },
+                )
             clean_data[field] = data[field]
 
         # Conforms to super-big-data.analytics.events schema.

--- a/reload_app/app.py
+++ b/reload_app/app.py
@@ -229,7 +229,7 @@ class App(Router):
                 return Response('bad request maybe check field type\n', status=400)
 
             if type(data[field]) != typ:
-                return client.captureMessage('field type does not match whitelisted type', level='warning')
+                client.captureMessage('field type does not match whitelisted type', level='warning')
 
             clean_data[field] = data[field]
 

--- a/reload_app/app.py
+++ b/reload_app/app.py
@@ -230,6 +230,7 @@ class App(Router):
 
             if type(data[field]) != typ:
                 return client.captureMessage('field type does not match whitelisted type', level='warning')
+
             clean_data[field] = data[field]
 
         # Conforms to super-big-data.analytics.events schema.

--- a/reload_app/tests.py
+++ b/reload_app/tests.py
@@ -43,7 +43,7 @@ class AppTests(TestCase):
         sent_data.update(
             event_name='assistant.guide_dismissed',
             guide=5,
-            step='6',
+            step=6,
             unknown_field='something',
         )
 
@@ -67,6 +67,27 @@ class AppTests(TestCase):
             if key not in ('event_name', 'unknown_field'):
                 assert key in data
         assert 'unknown_field' not in data
+
+    def test_bad_field_input(self):
+        sent_data = {
+            'url': 'https://sentry.io/',
+            'referrer': '/referrer/',
+            'user_id': '11',
+        }
+        resp = self.client.post('/page/', data=json.dumps(sent_data))
+        assert resp.status_code == 201
+
+        # /events/ endpoint.
+        sent_data.update(
+            event_name='assistant.guide_dismissed',
+            guide=5,
+            step='6',
+            unknown_field='something',
+        )
+
+        # make sure if field type doesn't match that we reject
+        resp = self.client.post('/event/', data=json.dumps(sent_data))
+        assert resp.status_code == 400
 
     def test_bad_input(self):
         sent_data = {

--- a/reload_app/tests.py
+++ b/reload_app/tests.py
@@ -81,12 +81,6 @@ class AppTests(TestCase):
         resp = self.client.post('/event/', data=json.dumps(sent_data))
         assert resp.status_code == 400
 
-        # bad type - can't coerce into prespecified
         sent_data.update(event_name='assistant.guide_dismissed', step='bad type')
-        resp = self.client.post('/event/', data=json.dumps(sent_data))
-        assert resp.status_code == 400
-
-        # bad type - can coerce but doesn't match prespecified
-        sent_data.update(event_name='assistant.guide_dismissed', step='6')
         resp = self.client.post('/event/', data=json.dumps(sent_data))
         assert resp.status_code == 400

--- a/reload_app/tests.py
+++ b/reload_app/tests.py
@@ -68,27 +68,6 @@ class AppTests(TestCase):
                 assert key in data
         assert 'unknown_field' not in data
 
-    def test_bad_field_input(self):
-        sent_data = {
-            'url': 'https://sentry.io/',
-            'referrer': '/referrer/',
-            'user_id': '11',
-        }
-        resp = self.client.post('/page/', data=json.dumps(sent_data))
-        assert resp.status_code == 201
-
-        # /events/ endpoint.
-        sent_data.update(
-            event_name='assistant.guide_dismissed',
-            guide=5,
-            step='6',
-            unknown_field='something',
-        )
-
-        # make sure if field type doesn't match that we reject
-        resp = self.client.post('/event/', data=json.dumps(sent_data))
-        assert resp.status_code == 400
-
     def test_bad_input(self):
         sent_data = {
             'url': '/url/',
@@ -102,6 +81,12 @@ class AppTests(TestCase):
         resp = self.client.post('/event/', data=json.dumps(sent_data))
         assert resp.status_code == 400
 
+        # bad type - can't coerce into prespecified
         sent_data.update(event_name='assistant.guide_dismissed', step='bad type')
+        resp = self.client.post('/event/', data=json.dumps(sent_data))
+        assert resp.status_code == 400
+
+        # bad type - can coerce but doesn't match prespecified
+        sent_data.update(event_name='assistant.guide_dismissed', step='6')
         resp = self.client.post('/event/', data=json.dumps(sent_data))
         assert resp.status_code == 400


### PR DESCRIPTION
Adding in an extra check just for `events` endpoint (don't care about page, but can add there as well. Will reject if you are sending a different data type than specified in VALID_EVENTS. Not sure if this is too harsh.

conclusion: Sending a sentry warning
