### PR TITLE
add more fields and change event name

### DIFF
--- a/reload_app/app.py
+++ b/reload_app/app.py
@@ -47,6 +47,13 @@ VALID_EVENTS = {
     'issue.search': {
         'query': str,
     },
+    'issue_error_banner.viewed': {
+       'org_id': int,
+       'platform': str,
+       'group': str,
+       'error_type': list,
+       'error_message': str,
+    },
     'platformpicker.search': {
         'query': str,
         'num_results': int,
@@ -86,11 +93,6 @@ VALID_EVENTS = {
         'link': str,
         'title': str,
     },
-    'sourcemap.sourcemap_error': {
-       'org_id': int,
-       'group': str,
-       'error_type': list,
-   },
 }
 
 # Prefix event names to avoid collisions with events from Sentry backend.

--- a/reload_app/app.py
+++ b/reload_app/app.py
@@ -93,6 +93,11 @@ VALID_EVENTS = {
         'link': str,
         'title': str,
     },
+    'sourcemap.sourcemap_error': {
+       'org_id': int,
+       'group': str,
+       'error_type': list,
+    },
 }
 
 # Prefix event names to avoid collisions with events from Sentry backend.


### PR DESCRIPTION
> We'd like to dive a bit deeper into exactly what issue errors are being seen by users. To that effect, we need a bit more data:

> 1. Change type from `sourcemap.sourcemap_error` to the more generic `issue_error_banner.viewed` (analytics events generally use underscore at sentry)
> 2. Add error message and platform or sdk to event payload



https://getsentry.atlassian.net/browse/SE-77