### PR TITLE
whitelist more releases clicks

### DIFF
--- a/reload_app/events.py
+++ b/reload_app/events.py
@@ -119,6 +119,16 @@ VALID_EVENTS = {
         'project_id': int,
         'steps': list,
     },
+    'releases.progress_bar_clicked_next': {
+        'org_id': int,
+        'project_id': int,
+        'cta': str,
+    },
+    'releases.progress_bar_closed': {
+        'org_id': int,
+        'project_id': int,
+        'action': str,
+    },
     'releases.tab_viewed': {
         'org_id': int,
         'project_id': int,


### PR DESCRIPTION
Added two more click events for when they click the cta and for when they close the bar- whitelisting here.

Related to https://github.com/getsentry/sentry/pull/10408/files