### PR TITLE
fix: Add safety event for sample event experiment

### DIFF
--- a/reload_app/events.py
+++ b/reload_app/events.py
@@ -150,6 +150,11 @@ VALID_EVENTS = {
         'project_id': int,
         'source': str,
     },
+    'sample_event.button_viewed2': {
+        'org_id': int,
+        'project_slug': str,
+        'source': str,
+    },
     'install_prompt.banner_viewed': {
         'org_id': int,
         'page': str,


### PR DESCRIPTION
This is mainly a safety measure. Just in case some random ipad or browser somewhere handles this differently and doest send the project_id I'm collecting in `sample_event.button_viewed`.

Related sentry event: https://sentry.io/sentry/javascript/issues/764141265/
