### PR TITLE
add cta to progress bar viewed events

### DIFF
--- a/reload_app/events.py
+++ b/reload_app/events.py
@@ -203,6 +203,7 @@ VALID_EVENTS = {
         'org_id': int,
         'project_id': int,
         'steps': list,
+        'cta': str,
     },
     'releases.progress_bar_clicked_next': {
         'org_id': int,


### PR DESCRIPTION
related to https://github.com/getsentry/sentry/pull/11149

Adds the cta to the progress bar viewed events. Can be deduced but this makes it easier