### PR TITLE
fix: includes -> indexOf for compatibility

### DIFF
--- a/client/ra.js
+++ b/client/ra.js
@@ -41,7 +41,7 @@ const assign =
 
 const getTLD = () => {
   // For development environments
-  if (["127.0.0.1", "0.0.0.0", "localhost"].includes(location.hostname)) {
+  if (["127.0.0.1", "0.0.0.0", "localhost"].indexOf(location.hostname) >= 0) {
     return location.host;
   }
 


### PR DESCRIPTION
`.includes` isn't supported well enough, so sentry.io is constantly blowing up on this.