### PR TITLE
feat(redirect): Add event to track deprecated URLs

### DIFF
--- a/reload_app/events.py
+++ b/reload_app/events.py
@@ -241,6 +241,7 @@ VALID_EVENTS = {
     "legacy_urls_global_views.redirect": {
         "from": str,
         "org_id": int,
+        "project_id": int,
     },
     "member_limit_modal.seen": {
         "org_id": int,

--- a/reload_app/events.py
+++ b/reload_app/events.py
@@ -237,6 +237,11 @@ VALID_EVENTS = {
         "org_id": int,
         "project_id": int,
     },
+    # Track the redirects from URLs of pre-Sentry 10 to post-Sentry 10 URLs
+    "legacy_urls_pre_sentry10.redirect": {
+        "from": str,
+        "to": str
+    },
     "member_limit_modal.seen": {
         "org_id": int,
     },

--- a/reload_app/events.py
+++ b/reload_app/events.py
@@ -240,7 +240,7 @@ VALID_EVENTS = {
     # Track the redirects from legacy URLs of cross-project views (global views)
     "legacy_urls_global_views.redirect": {
         "from": str,
-        "to": str
+        "org_id": int,
     },
     "member_limit_modal.seen": {
         "org_id": int,

--- a/reload_app/events.py
+++ b/reload_app/events.py
@@ -237,8 +237,8 @@ VALID_EVENTS = {
         "org_id": int,
         "project_id": int,
     },
-    # Track the redirects from URLs of pre-Sentry 10 to post-Sentry 10 URLs
-    "legacy_urls_pre_sentry10.redirect": {
+    # Track the redirects from legacy URLs of cross-project views (global views)
+    "legacy_urls_global_views.redirect": {
         "from": str,
         "to": str
     },

--- a/reload_app/events.py
+++ b/reload_app/events.py
@@ -237,11 +237,11 @@ VALID_EVENTS = {
         "org_id": int,
         "project_id": int,
     },
-    # Track the redirects from legacy URLs of cross-project views (global views)
-    "legacy_urls_global_views.redirect": {
-        "from": str,
-        "org_id": int,
-        "project_id": int,
+    # Track the redirects from deprecated URLs to newer URLs
+    "deprecated_urls.redirect": {
+        "feature": str,
+        "url": str,  # the URL being redirected from
+        "org_id": int
     },
     "member_limit_modal.seen": {
         "org_id": int,


### PR DESCRIPTION
Add event to track deprecated URLs.

-------

We'll be redirecting users who are consuming deprecated URLs, and they will be redirected to newer URLs. We'd also like to be able track these redirects to ensure we will bake in support for these redirects.

Associated PR at https://github.com/getsentry/sentry/pull/13722

Part of SEN-772
