### PR TITLE
feat(metrics): Track performance of organization details

### DIFF
--- a/reload_app/metrics/__init__.py
+++ b/reload_app/metrics/__init__.py
@@ -18,7 +18,7 @@ VALID_METRICS = {
     "app.api.request-abort": ("increment", []),
     # used for performance measurements such as
     # when /organizations/{org_slug}/ endpoint finishes and state is refreshed
-    "app.component.perf": ("timing", ["route", "organization_id"]),
+    "app.component.perf": ("timing", ["name", "route", "organization_id"]),
 }
 
 VALID_GLOBAL_TAGS = {"release"}

--- a/reload_app/metrics/__init__.py
+++ b/reload_app/metrics/__init__.py
@@ -16,8 +16,9 @@ VALID_METRICS = {
     "app.api.request-success": ("timing", ["path", "status"]),
     "app.api.request-error": ("timing", ["path", "status"]),
     "app.api.request-abort": ("increment", []),
+    # used for performance measurements such as 
     # when /organizations/{org_slug}/ endpoint finishes and state is refreshed
-    "app.component.organization-details-fetch": ("timing", ["route", "organization_id"]),
+    "app.component.perf": ("timing", ["route", "organization_id"]),
 }
 
 VALID_GLOBAL_TAGS = {"release"}

--- a/reload_app/metrics/__init__.py
+++ b/reload_app/metrics/__init__.py
@@ -16,7 +16,7 @@ VALID_METRICS = {
     "app.api.request-success": ("timing", ["path", "status"]),
     "app.api.request-error": ("timing", ["path", "status"]),
     "app.api.request-abort": ("increment", []),
-    # used for performance measurements such as 
+    # used for performance measurements such as
     # when /organizations/{org_slug}/ endpoint finishes and state is refreshed
     "app.component.perf": ("timing", ["route", "organization_id"]),
 }

--- a/reload_app/metrics/__init__.py
+++ b/reload_app/metrics/__init__.py
@@ -16,6 +16,8 @@ VALID_METRICS = {
     "app.api.request-success": ("timing", ["path", "status"]),
     "app.api.request-error": ("timing", ["path", "status"]),
     "app.api.request-abort": ("increment", []),
+    # when /organizations/{org_slug}/ endpoint finishes and state is refreshed
+    "app.component.organization-details-fetch": ("timing", ["route", "organization_id"]),
 }
 
 VALID_GLOBAL_TAGS = {"release"}


### PR DESCRIPTION
Added `app.component.perf` as a valid metric so it is tracked and forwarded to data dog. This metric was added by [this pr](https://github.com/getsentry/sentry/pull/14820).

Refs SEN-1058