### PR TITLE
fix(analytics): remove project_id from sidebar.item_clicked event

### DIFF
--- a/reload_app/events.py
+++ b/reload_app/events.py
@@ -793,7 +793,6 @@ VALID_EVENTS = {
     },
     "sidebar.item_clicked": {
         "org_id": int,
-        "project_id": int,
         "sidebar_item_id": str,
         "dest": str,  # the URL the click will bring you to
     },


### PR DESCRIPTION
The project_id is an optional parameter to the `sidebar.item_clicked` event (only passed when you pick a plugin which brings up the project dropdown). The result is that when the value is not provided, we get the following warning:
```
WARNING: Property key "project_id" with invalid value type undefined, ignoring
```
Reload will ignore any event which does not have `project_id` set. Best course is to remove it