### PR TITLE
fix(analytics): Remove user id from new project event

### DIFF
--- a/reload_app/events.py
+++ b/reload_app/events.py
@@ -554,7 +554,6 @@ VALID_EVENTS = {
         "org_id": int,
         "project_id": int,
         "rule_type": str,
-        "user_id": int,
         "custom_rule_id": int,
     },
     "omnisearch.open": {},


### PR DESCRIPTION
User id is redundant as it's automatically logged, thus removing it.