### PR TITLE
fix(events) Remove user_id definition

### DIFF
--- a/reload_app/events.py
+++ b/reload_app/events.py
@@ -148,19 +148,15 @@ VALID_EVENTS = {
     },
     "discover_v2.saved_query.search": {
         "org_id": int,
-        "user_id": int,
     },
     "discover_v2.results.download_csv": {
         "org_id": int,
-        "user_id": int,
     },
     "discover_v2.results.drilldown": {
         "org_id": int,
-        "user_id": int,
     },
     "discover_v2.results.cellaction": {
         "org_id": int,
-        "user_id": int,
         "action": str,
     },
     "discover_v2.y_axis_change": {


### PR DESCRIPTION
Inherit the default user_id attribute defintion.

If you've updated the JS client, remember to update...

- [ ] [App](https://github.com/getsentry/getsentry/blob/master/getsentry/templates/sentry/includes/segment.html)
- [ ] [Blog](https://github.com/getsentry/blog/blob/6b61c5b89c44f5ddbbe76ce8861e0a2a8f6242e5/src/_includes/trackers/reload.html)
- [ ] [Docs](https://github.com/getsentry/sentry-docs/blob/5ac5ae51bd91ae27ecc1aa3b4a8feeef97cf22ce/design/templates/layout.html)
- [ ] [Marketing](https://github.com/getsentry/sentry.io/blob/master/src/_assets/js/reload.js)
