### PR TITLE
meta(git): Add .venv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 venv
+.venv
 node_modules/*
 *.pyc
 .cache


### PR DESCRIPTION
Our [docs here](https://develop.sentry.dev/environment/#virtual-environment) recommends naming the virtualenv folder as `.venv`