### PR TITLE
feat(perf): Add event for the new landing specifically

### DIFF
--- a/reload_app/events.py
+++ b/reload_app/events.py
@@ -731,6 +731,9 @@ VALID_EVENTS = {
     "performance_views.landingv2.content": {
         "org_id": int,
     },
+    "performance_views.landingv2.new_landing": {
+        "org_id": int,
+    },
     "performance_views.landingv2.display_change": {
         "org_id": int,
         "change_to_display": str,


### PR DESCRIPTION
### Summary
The other event is capturing whether they are seeing the landing content, which switches them between the beta and non-beta view. This will capture specifically if they are on the new view
