### PR TITLE
fix(build): replace PGP check with sha256sum

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,48 +5,27 @@ RUN groupadd -r reload && useradd -r -g reload reload
 ENV PIP_NO_CACHE_DIR off
 ENV PIP_DISABLE_PIP_VERSION_CHECK on
 
-# grab gosu for easy step-down from root
-# grab tini for signal processing and zombie killing
+ENV GOSU_VERSION=1.12 \
+    GOSU_SHA256=0f25a21cf64e58078057adc78f38705163c1d564a959ff30a891c31917011a54 \
+    TINI_VERSION=0.19.0 \
+    TINI_SHA256=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c
+
 RUN set -x \
-    && export GOSU_VERSION=1.11 \
-    && export TINI_VERSION=0.18.0 \
-    \
      && fetchDeps=" \
-        dirmngr \
-        gnupg \
         wget \
     " \
     && apt-get update && apt-get install -y --no-install-recommends $fetchDeps && rm -rf /var/lib/apt/lists/* \
-    \
-    && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
-    && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
-    && export GNUPGHOME="$(mktemp -d)" \
-     && for key in \
-      B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-    ; do \
-      gpg --batch --keyserver hkps://mattrobenolt-keyserver.global.ssl.fastly.net:443 --recv-keys "$key" ; \
-    done \
-    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && rm /usr/local/bin/gosu.asc \
+    # grab gosu for easy step-down from root
+    && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64" \
+    && echo "$GOSU_SHA256 /usr/local/bin/gosu" | sha256sum --check --status \
     && chmod +x /usr/local/bin/gosu \
     && gosu nobody true \
-    \
-    && wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini" \
-    && wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini.asc" \
-    && export GNUPGHOME="$(mktemp -d)" \
-    && for key in \
-      595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
-    ; do \
-      gpg --batch --keyserver hkps://mattrobenolt-keyserver.global.ssl.fastly.net:443 --recv-keys "$key" ; \
-    done \
-    && gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
-    && gpgconf --kill all \
-    && rm /usr/local/bin/tini.asc \
+    # grab tini for signal processing and zombie killing
+    && wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-amd64" \
+    && echo "$TINI_SHA256 /usr/local/bin/tini" | sha256sum --check --status \
     && chmod +x /usr/local/bin/tini \
     && tini -h \
-    \
-    && rm -r "$GNUPGHOME" \
-    && apt-get purge -y --auto-remove wget
+    && apt-get purge -y --auto-remove $fetchDeps
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         libmaxminddb-dev \


### PR DESCRIPTION
Checking against PGP keyservers is flaky and old and busted, just use a checksum. We do this for Sentry here: https://github.com/getsentry/sentry/blob/master/docker/Dockerfile#L20

Also upgrades gosu and tini each a minor version to match what's in Sentry, the changes are trivial.