### PR TITLE
Skip field validation if corresponding data is None

### DIFF
--- a/reload_app/app.py
+++ b/reload_app/app.py
@@ -171,7 +171,7 @@ class App(Router):
                 pass
 
         for field, type_expected in VALID_EVENTS[data["event_name"]].items():
-            if field not in data:
+            if field not in data or data[field] is None:
                 continue
             try:
                 type_expected(data[field])


### PR DESCRIPTION
Jira issue: https://getsentry.atlassian.net/browse/OPS-949
Why I want to fix this? Because it is at the top in our Google Error Reporting dashboard, and I'd like to make it cleaner.

Sometimes `data` dictionary contains `dashboard_id` with `None` value. With that, `int(None)` is being executed in try block, giving `TypeError` exception. This PR does not fix the source of `dashboard_id = None` (probably this is right thing to do), but just skips such events from validation.

Should fix these sentry issues:
https://sentry.io/organizations/sentry/issues/1809964681/
https://sentry.io/organizations/sentry/issues/1809964689/