### PR TITLE
fix(discover): Removes events for tracking Discover Queries

### DIFF
--- a/reload_app/events.py
+++ b/reload_app/events.py
@@ -492,10 +492,6 @@ VALID_EVENTS = {
     "discover_views.add_to_dashboard.confirm": {
         "org_id": int,
     },
-    "discover_views.query": {
-        "org_id": int,
-        "conditions": list,
-    },
     "environmentselector.toggle": {
         "action": str,
         "path": str,

--- a/reload_app/events.py
+++ b/reload_app/events.py
@@ -338,15 +338,6 @@ VALID_EVENTS = {
         "display_type": str,
         "widget_type": str,
     },
-    "discover.query": {
-        "org_id": int,
-        "projects": list,
-        "fields": list,
-        "conditions": list,
-        "aggregations": list,
-        "orderby": str,
-        "limit": int,
-    },
     "discover_search.failed": {
         "org_id": int,
         "search_type": str,


### PR DESCRIPTION
Stops sending analytics for discover queries from the discover results page
Sentry: https://github.com/getsentry/sentry/pull/33085

No longer using `discover_views.query` and `discover.query` doesn't seem to be in use