### PR TITLE
feat(perf): Track chart display changes for span summary page

### DIFF
--- a/reload_app/events.py
+++ b/reload_app/events.py
@@ -1234,7 +1234,7 @@ VALID_EVENTS = {
         "org_id": int,
         "action": str,
     },
-    "performance_views.spanSummary.change_chart": {
+    "performance_views.span_summary.change_chart": {
         "org_id": int,
         "change_to_display": str,
     },

--- a/reload_app/events.py
+++ b/reload_app/events.py
@@ -1234,6 +1234,10 @@ VALID_EVENTS = {
         "org_id": int,
         "action": str,
     },
+    "performance_views.span_summary.change_chart": {
+        "org_id": int,
+        "change_to_display": str,
+    },
     "performance_views.spans.spans_tab_clicked": {
         "org_id": int,
     },

--- a/reload_app/events.py
+++ b/reload_app/events.py
@@ -1234,7 +1234,7 @@ VALID_EVENTS = {
         "org_id": int,
         "action": str,
     },
-    "performance_views.span_summary.change_chart": {
+    "performance_views.spanSummary.change_chart": {
         "org_id": int,
         "change_to_display": str,
     },


### PR DESCRIPTION
Adding an event to track when users switch display time for span self time. I'm trying to see how many users actually choose to view histogram over timeseries.

Fixes PERF-1417
