### PR TITLE
fix(requirements): Pin click to version 8.0.4 in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Werkzeug==0.15.2
 datadog==0.28.0
+click==8.0.4
 google-cloud-bigquery==1.11.2
 google-cloud-pubsub==0.40.0
 sentry-sdk==1.4.3


### PR DESCRIPTION
Similar to https://github.com/getsentry/sentry/pull/33008, pin click dep due to https://github.com/psf/black/issues/2964