### PR TITLE
feat(alerts): Add parameters for duplicate rule analytics

### DIFF
--- a/reload_app/events.py
+++ b/reload_app/events.py
@@ -954,6 +954,8 @@ VALID_EVENTS = {
         "org_id": int,
         "project_id": int,
         "alert_type": str,
+        "duplicate_rule": str,
+        "session_id": str,
     },
     "edit_alert_rule.viewed": {
         "org_id": int,


### PR DESCRIPTION
This adds parameters for 'new_alert_rule.viewed' analytics event.

Ref: https://github.com/getsentry/sentry/pull/34526

If you've updated the JS client, remember to update...

- [x] [App](https://github.com/getsentry/getsentry/blob/master/getsentry/templates/sentry/includes/segment.html)
- [x] ~~[Blog](https://github.com/getsentry/blog/blob/6b61c5b89c44f5ddbbe76ce8861e0a2a8f6242e5/src/_includes/trackers/reload.html)~~
- [x] [Docs](https://github.com/getsentry/sentry-docs/blob/5ac5ae51bd91ae27ecc1aa3b4a8feeef97cf22ce/design/templates/layout.html)
- [x] ~~[Marketing](https://github.com/getsentry/sentry.io/blob/master/src/_assets/js/reload.js)~~
