### PR TITLE
feat(alerts): Add analytics for alert wizard v3

### DIFF
--- a/reload_app/events.py
+++ b/reload_app/events.py
@@ -955,6 +955,7 @@ VALID_EVENTS = {
         "project_id": int,
         "alert_type": str,
         "duplicate_rule": str,
+        "wizard_v3": str,
         "session_id": str,
     },
     "edit_alert_rule.viewed": {


### PR DESCRIPTION
This adds the parameter `wizard_v3` to the `new_alert_rule.viewed` analytics events to see the usage of the Alert Wizard V3.

If you've updated the JS client, remember to update...

- [ ] [App](https://github.com/getsentry/getsentry/blob/master/getsentry/templates/sentry/includes/segment.html)
- [ ] [Blog](https://github.com/getsentry/blog/blob/6b61c5b89c44f5ddbbe76ce8861e0a2a8f6242e5/src/_includes/trackers/reload.html)
- [ ] [Docs](https://github.com/getsentry/sentry-docs/blob/5ac5ae51bd91ae27ecc1aa3b4a8feeef97cf22ce/design/templates/layout.html)
- [ ] [Marketing](https://github.com/getsentry/sentry.io/blob/master/src/_assets/js/reload.js)
