### PR TITLE
feat(perf): Add analytics events for transaction summary, vital detail, and trace view

### DIFF
--- a/reload_app/events.py
+++ b/reload_app/events.py
@@ -1338,11 +1338,9 @@ VALID_EVENTS = {
     },
     "performance_views.event_details.search_query": {
         "org_id": int,
-        "query": str,
     },
     "performance_views.event_details.open_span_details": {
         "org_id": int,
-        "description": str,
         "operation": str,
     },
     "performance_views.event_details.anchor_span": {

--- a/reload_app/events.py
+++ b/reload_app/events.py
@@ -1329,9 +1329,6 @@ VALID_EVENTS = {
         "org_id": int,
         "status": str
     },
-    "performance_views.transaction_summary.view": {
-        "org_id": int,
-    },
     "performance_views.all_events.open_in_discover": {
         "org_id": int,
     },

--- a/reload_app/events.py
+++ b/reload_app/events.py
@@ -1297,11 +1297,24 @@ VALID_EVENTS = {
         "org_id": int,
         "sort_column": str,
     },
+    "performance_views.vital_detail.switch_vital": {
+        "org_id": int,
+        "from_vital": str,
+        "to_vital": str,
+    },
     "performance_views.vital_detail.view": {
         "org_id": int,
     },
     "performance_views.trace_view.view": {
         "org_id": int,
+    },
+    "performance_views.trace_view.open_in_discover": {
+        "org_id": int,
+    },
+    "performance_views.trace_view.open_transaction_details": {
+        "org_id": int,
+        "operation": str,
+        "transaction": str,
     },
     "performance_views.team_key_transaction.set": {
         "org_id": int,
@@ -1315,6 +1328,9 @@ VALID_EVENTS = {
     "performance_views.transaction_summary.status_breakdown_click": {
         "org_id": int,
         "status": str
+    },
+    "performance_views.transaction_summary.view": {
+        "org_id": int,
     },
     "performance_views.all_events.open_in_discover": {
         "org_id": int,

--- a/reload_app/events.py
+++ b/reload_app/events.py
@@ -1283,6 +1283,9 @@ VALID_EVENTS = {
         "org_id": int,
         "change_to_display": str,
     },
+    "performance_views.span_summary.view": {
+        "org_id": int,
+    },
     "performance_views.spans.spans_tab_clicked": {
         "org_id": int,
     },
@@ -1314,6 +1317,26 @@ VALID_EVENTS = {
         "status": str
     },
     "performance_views.all_events.open_in_discover": {
+        "org_id": int,
+    },
+    "performance_views.event_details.filter_by_op": {
+        "org_id": int,
+        "operation": str,
+    },
+    "performance_views.event_details.search_query": {
+        "org_id": int,
+        "query": str,
+    },
+    "performance_views.event_details.open_span_details": {
+        "org_id": int,
+        "description": str,
+        "operation": str,
+    },
+    "performance_views.event_details.anchor_span": {
+        "org_id": int,
+        "span_id": str,
+    },
+    "performance_views.event_details.json_button_click": {
         "org_id": int,
     },
     "span_view.embedded_child.hide": {


### PR DESCRIPTION
Adds instrumentation for the following events:

### Event Details
- Filter by operation dropdown
- Searchbar
- Click on a span to view its details
- Anchoring a span
- Click button to view JSON data of the event

### Vital Detail Page
- Switch the vital type from the dropdown

### Trace View
- Open in Discover
- Transaction clicked

Also adds an event for when a user views the Span Summary page, which I had forgotten to add earlier.