### PR TITLE
feat(perf): Add selected project platforms to analytics events for Performance page views

### DIFF
--- a/reload_app/events.py
+++ b/reload_app/events.py
@@ -1051,6 +1051,7 @@ VALID_EVENTS = {
     "performance_views.change_view": {
         "org_id": int,
         "view_name": str,
+        "project_platforms": str,
     },
     "performance_views.landingv2.content": {
         "org_id": int,

--- a/reload_app/events.py
+++ b/reload_app/events.py
@@ -1109,6 +1109,7 @@ VALID_EVENTS = {
     },
     "performance_views.overview.view": {
         "org_id": int,
+        "project_platforms": str,
     },
     "performance_views.overview.sort": {
         "org_id": int,
@@ -1116,6 +1117,7 @@ VALID_EVENTS = {
     },
     "performance_views.overview.navigate.summary": {
         "org_id": int,
+        "project_platforms": str,
     },
     "performance_views.overview.search": {
         "org_id": int,
@@ -1180,6 +1182,7 @@ VALID_EVENTS = {
     },
     "performance_views.tags.tags_tab_clicked": {
         "org_id": int,
+        "project_platforms": str,
     },
     "performance_views.tags.interaction": {
         "org_id": int,
@@ -1239,6 +1242,7 @@ VALID_EVENTS = {
     },
     "performance_views.vitals.vitals_tab_clicked": {
         "org_id": int,
+        "project_platforms": str,
     },
     "performance_views.vitals.reset_view": {
         "org_id": int,
@@ -1261,6 +1265,7 @@ VALID_EVENTS = {
     },
     "performance_views.events.events_tab_clicked": {
         "org_id": int,
+        "project_platforms": str,
     },
     "performance_views.transactionEvents.cellaction": {
         "org_id": int,
@@ -1285,9 +1290,11 @@ VALID_EVENTS = {
     },
     "performance_views.span_summary.view": {
         "org_id": int,
+        "project_platforms": str,
     },
     "performance_views.spans.spans_tab_clicked": {
         "org_id": int,
+        "project_platforms": str,
     },
     "performance_views.spans.change_op": {
         "org_id": int,
@@ -1304,6 +1311,7 @@ VALID_EVENTS = {
     },
     "performance_views.vital_detail.view": {
         "org_id": int,
+        "project_platforms": str,
     },
     "performance_views.trace_view.view": {
         "org_id": int,
@@ -1349,6 +1357,10 @@ VALID_EVENTS = {
     },
     "performance_views.event_details.json_button_click": {
         "org_id": int,
+    },
+    "performance_views.anomalies.anomalies_tab_clicked": {
+        "org_id": int,
+        "project_platforms": str,
     },
     "span_view.embedded_child.hide": {
         "org_id": int,


### PR DESCRIPTION
This PR passes a string containing the selected project platform(s) for each relevant pageview event within Performance. This data could be useful, since it would allow us to see different workflows within Performance depending on the type of project selected.

Adds this data to the following events:

- Landing Page view
- Trends Page view
- Transaction Summary Page view
- Transaction Summary Tab Views
- Span Summary Page View
- Event Details Page View
- Vital Detail Page View