### PR TITLE
feat(subscription): Add usagelog filter clicked event

### DIFF
--- a/reload_app/events.py
+++ b/reload_app/events.py
@@ -1517,7 +1517,7 @@ VALID_EVENTS = {
         "error_type": list,
     },
     'subscription_page.usagelog_filter.clicked': {
-        "org_id": int, 
+        "org_id": int,
         "selection": str,
     },
     "team_insights.viewed": {

--- a/reload_app/events.py
+++ b/reload_app/events.py
@@ -1516,6 +1516,10 @@ VALID_EVENTS = {
         "group": str,
         "error_type": list,
     },
+    'subscription_page.usagelog_filter.clicked': {
+        "org_id": int, 
+        "selection": str,
+    },
     "team_insights.viewed": {
         "org_id": int,
     },


### PR DESCRIPTION
This adds an event for clicks on the usage log's filter drop down menu.
[getsentry/getsentry/#7741](https://github.com/getsentry/getsentry/pull/7741)