### PR TITLE
feat: remove issue_details.viewed from schema

### DIFF
--- a/reload_app/events.py
+++ b/reload_app/events.py
@@ -900,15 +900,6 @@ VALID_EVENTS = {
         "alert_rule_id": str,
         "alert_type": str,
     },
-    "issue_details.viewed": {
-        "org_id": int,
-        "group_id": int,
-        "issue_category": str,
-        "project_id": int,
-        "alert_date": str,
-        "alert_rule_id": str,
-        "alert_type": str,
-    },
     "issue_details.performance.autogrouped_siblings_toggle": {
         "org_id": int,
     },


### PR DESCRIPTION
We don't need an explicit schema for the `issue_details.viewed` event because it's the new style analytics that honors what the client sends even if the event isn't defined.