### PR TITLE
fix: remove user feedback events

### DIFF
--- a/reload_app/events.py
+++ b/reload_app/events.py
@@ -1631,18 +1631,6 @@ VALID_EVENTS = {
     "usage_exceeded_modal.seen": {
         "org_id": int,
     },
-    "user_feedback.viewed": {
-        "org_id": int,
-        "projects": list,
-    },
-    "user_feedback.docs_clicked": {
-        "org_id": int,
-        "projects": list,
-    },
-    "user_feedback.dialog_opened": {
-        "org_id": int,
-        "projects": list,
-    },
     "zendesk_link.viewed": {
         "org_id": int,
     },


### PR DESCRIPTION
Since these events come from the new analytics event which doesn't require a reload schema, we can delete these events which are causing problems because `projects` is now a string instead of a list which didn't work well with Amplitude