### PR TITLE
move reload to google artifact registry

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,19 +1,29 @@
 steps:
-- name: 'gcr.io/cloud-builders/docker'
-  entrypoint: 'bash'
-  args: [
-    '-c',
-    'docker pull us.gcr.io/$PROJECT_ID/$REPO_NAME:latest || true',
-  ]
-- name: 'gcr.io/cloud-builders/docker'
-  args: [
-            'build',
-            '-t', 'us.gcr.io/$PROJECT_ID/$REPO_NAME:latest',
-            '-t', 'us.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA',
-            '--cache-from', 'us.gcr.io/$PROJECT_ID/$REPO_NAME:latest',
-            '.'
-        ]
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      [
+        'build',
+        '-t',
+        'us-central1-docker.pkg.dev/$PROJECT_ID/reload/image:latest',
+        '-t',
+        'us-central1-docker.pkg.dev/$PROJECT_ID/reload/image:$COMMIT_SHA',
+        '--build-arg',
+        'BUILDKIT_INLINE_CACHE=1',
+        '--cache-from',
+        'us-central1-docker.pkg.dev/$PROJECT_ID/reload/image:latest',
+        '.',
+      ]
+    env: [DOCKER_BUILDKIT=1]
+
+  - name: 'gcr.io/cloud-builders/docker'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        # Only push "latest" tag when building on "main"
+        [ "$BRANCH_NAME" != "main" ] && exit 0
+        docker push us-central1-docker.pkg.dev/$PROJECT_ID/reload/image:latest
+
 images: [
-  'us.gcr.io/$PROJECT_ID/$REPO_NAME:latest',
-  'us.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA',
-  ]
+  'us-central1-docker.pkg.dev/$PROJECT_ID/reload/image:$COMMIT_SHA',
+]

--- a/gocd/pipelines/reload.yaml
+++ b/gocd/pipelines/reload.yaml
@@ -31,7 +31,7 @@ pipelines:
                                     /devinfra/scripts/checks/googlecloud/checkcloudbuild.py \
                                     ${GO_REVISION_RELOAD_REPO} \
                                     internal-sentry \
-                                    "us.gcr.io/internal-sentry/github-getsentry-reload"
+                                    "us-central1-docker.pkg.dev/sentryio/reload/image"
             - deploy:
                   jobs:
                       deploy:
@@ -42,5 +42,5 @@ pipelines:
                                     /devinfra/scripts/k8s/k8stunnel \
                                     && /devinfra/scripts/k8s/k8s-deploy.py \
                                     --label-selector="service=reload" \
-                                    --image="us.gcr.io/internal-sentry/github-getsentry-reload:${GO_REVISION_RELOAD_REPO}" \
+                                    --image="us-central1-docker.pkg.dev/sentryio/reload/image:${GO_REVISION_RELOAD_REPO}" \
                                     --container-name="reload"


### PR DESCRIPTION
in the others I've done a 3 stage rollout but I can't really do that here because I need to also move this from `internal-sentry` (private repos) to sentryio (public repos)

I've locked the deploy pipeline while making the switch and this repo gets ~0 commits so it should be fine during transition