### PR TITLE
add missing dependency on six

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ geoip2==2.9.0
 ua-parser==0.8.0
 pyuwsgi==2.0.18.post0
 mywsgi==1.0.0
+six==1.16.0


### PR DESCRIPTION
apparently deps aren't frozen and this is broken:

```
  File "./reload_app/wsgi.py", line 1, in <module>
    from .app import make_app_from_environ
  File "./reload_app/app.py", line 10, in <module>
    from google.cloud import pubsub_v1
  File "/usr/local/lib/python3.7/site-packages/google/cloud/pubsub_v1/__init__.py", line 18, in <module>
    from google.cloud.pubsub_v1 import publisher
  File "/usr/local/lib/python3.7/site-packages/google/cloud/pubsub_v1/publisher/__init__.py", line 17, in <module>
    from google.cloud.pubsub_v1.publisher.client import Client
  File "/usr/local/lib/python3.7/site-packages/google/cloud/pubsub_v1/publisher/client.py", line 22, in <module>
    import six
ModuleNotFoundError: No module named 'six'
```