### PR TITLE
fix(cors) Add cors headers to error responses

### DIFF
--- a/reload_app/app.py
+++ b/reload_app/app.py
@@ -47,6 +47,7 @@ MAX_PAYLOAD_SIZE = 8_000
 def ok_response():
     return Response(status=201, headers=(("Access-Control-Allow-Origin", "*"),))
 
+
 def error_response(text, status):
     return Response(text, status=status, headers=(("Access-Control-Allow-Origin", "*"),))
 
@@ -156,7 +157,10 @@ class App(Router):
         try:
             data = load(request.stream)
         except Exception:
-            return error_response(f"bad request expecting json under {MAX_PAYLOAD_SIZE}\n", status=400)
+            return error_response(
+                f"bad request expecting json under {MAX_PAYLOAD_SIZE}\n",
+                status=400
+            )
 
         # pop off allow_no_schema since we don't want to pass it
         data.pop("allow_no_schema", None)

--- a/reload_app/app.py
+++ b/reload_app/app.py
@@ -49,7 +49,9 @@ def ok_response():
 
 
 def error_response(text, status):
-    return Response(text, status=status, headers=(("Access-Control-Allow-Origin", "*"),))
+    return Response(
+        text, status=status, headers=(("Access-Control-Allow-Origin", "*"),)
+    )
 
 
 def validate_user_id(uid):
@@ -158,8 +160,7 @@ class App(Router):
             data = load(request.stream)
         except Exception:
             return error_response(
-                f"bad request expecting json under {MAX_PAYLOAD_SIZE}\n",
-                status=400
+                f"bad request expecting json under {MAX_PAYLOAD_SIZE}\n", status=400
             )
 
         # pop off allow_no_schema since we don't want to pass it
@@ -191,7 +192,9 @@ class App(Router):
 
         # every schema-less event needs a user_id or organization_id
         if not data.get("user_id") and not data.get("organization_id"):
-            return error_response("bad request no user_id or organization_id", status=400)
+            return error_response(
+                "bad request no user_id or organization_id", status=400
+            )
 
         # blindly pass fields from the API to the event
         clean_data.update(data)

--- a/reload_app/tests.py
+++ b/reload_app/tests.py
@@ -139,6 +139,7 @@ class AppTests(TestCase):
         assert (
             resp.data == b"invalid_metric_name: bad request check if valid metric name"
         )
+        assert "Access-Control-Allow-Origin" in resp.headers
 
     def test_invalid_metric_tags(self):
         metric_data = {
@@ -149,6 +150,7 @@ class AppTests(TestCase):
         resp = self.client.post("/metric/", data=json.dumps(metric_data))
         assert resp.status_code == 400
         assert resp.data == b"app.page.body-load: bad request check if valid tag name"
+        assert "Access-Control-Allow-Origin" in resp.headers
 
     def test_globally_allowed_tags(self):
         metric_data = {
@@ -179,6 +181,7 @@ class AppTests(TestCase):
 
         resp = self.client.post("/metric/", data=data)
         assert resp.status_code == 400
+        assert "Access-Control-Allow-Origin" in resp.headers
 
         assert self.mock_dogstatsd.timing.call_count == 1
         assert self.mock_dogstatsd.timing.mock_calls[0] == call(
@@ -227,6 +230,7 @@ class AppTests(TestCase):
         sent_data = {"url": "/url/", "referrer": "/referrer/", "user_id": "10;"}
         resp = self.client.post("/page/", data=json.dumps(sent_data))
         assert resp.status_code == 400
+        assert "Access-Control-Allow-Origin" in resp.headers
 
     def test_oversized_payload(self):
         sent_data = {
@@ -241,6 +245,7 @@ class AppTests(TestCase):
         # Make sure oversized events aren't accepted.
         resp = self.client.post("/event/", data=json.dumps(sent_data))
         assert resp.status_code == 400
+        assert "Access-Control-Allow-Origin" in resp.headers
         assert resp.data == b"event exceeds max payload size of 8000\n"
         assert self.mock_publisher.publish.call_count == 0
 
@@ -272,3 +277,4 @@ class AppTests(TestCase):
         resp = self.client.post("/event/", data=json.dumps(sent_data))
         assert resp.status_code == 400
         assert self.mock_publisher.publish.call_count == 0
+        assert "Access-Control-Allow-Origin" in resp.headers


### PR DESCRIPTION
Error responses should have CORS headers so that we don't get warnings/errors in the javascript console on sentry.io

If you've updated the JS client, remember to update...

- [ ] [App](https://github.com/getsentry/getsentry/blob/master/getsentry/templates/sentry/includes/segment.html)
- [ ] [Blog](https://github.com/getsentry/blog/blob/6b61c5b89c44f5ddbbe76ce8861e0a2a8f6242e5/src/_includes/trackers/reload.html)
- [ ] [Docs](https://github.com/getsentry/sentry-docs/blob/5ac5ae51bd91ae27ecc1aa3b4a8feeef97cf22ce/design/templates/layout.html)
- [ ] [Marketing](https://github.com/getsentry/sentry.io/blob/master/src/_assets/js/reload.js)
