### PR TITLE
ref(gocd): use new google cloud check script

### DIFF
--- a/gocd/pipelines/reload.yaml
+++ b/gocd/pipelines/reload.yaml
@@ -41,8 +41,8 @@ pipelines:
                           elastic_profile_id: reload
                           tasks:
                               - script: |
-                                    /devinfra/scripts/k8s/k8stunnel \
-                                    && /devinfra/scripts/k8s/k8s-deploy.py \
+                                    /devinfra/scripts/get-cluster-credentials \
+                                    && k8s-deploy \
                                     --label-selector="service=reload" \
                                     --image="us-central1-docker.pkg.dev/sentryio/reload/image:${GO_REVISION_RELOAD_REPO}" \
                                     --container-name="reload"


### PR DESCRIPTION
Updating to use new google cloud check script as well as the console script entry point.

Will need to enable the gcloud build trigger (and name "build-reload") if this needs to be built again.

Please see: https://github.com/getsentry/devinfra-deployment-service/pull/698
