### PR TITLE
chore: use dhi-mirror as base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM us-docker.pkg.dev/sentryio/dhi/python:3.13-debian13-dev AS build
+FROM us-docker.pkg.dev/sentryio/dhi-mirror/python:3.13-debian13-dev AS build
 
 ENV PIP_NO_CACHE_DIR=off \
     PIP_DISABLE_PIP_VERSION_CHECK=on
@@ -8,7 +8,7 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 
-FROM us-docker.pkg.dev/sentryio/dhi/python:3.13-debian13
+FROM us-docker.pkg.dev/sentryio/dhi-mirror/python:3.13-debian13
 
 # Python packages installed in the build stage
 COPY --from=build /opt/python/lib/python3.13/site-packages /opt/python/lib/python3.13/site-packages


### PR DESCRIPTION
If you've updated the JS client, remember to update...

- [ ] [App](https://github.com/getsentry/getsentry/blob/master/getsentry/templates/sentry/includes/segment.html)
- [ ] [Blog](https://github.com/getsentry/blog/blob/6b61c5b89c44f5ddbbe76ce8861e0a2a8f6242e5/src/_includes/trackers/reload.html)
- [ ] [Docs](https://github.com/getsentry/sentry-docs/blob/5ac5ae51bd91ae27ecc1aa3b4a8feeef97cf22ce/design/templates/layout.html)
- [ ] [Marketing](https://github.com/getsentry/sentry.io/blob/master/src/_assets/js/reload.js)
