### PR TITLE
ci: build and push production image via GitHub Actions

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,46 @@
+name: image
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - releases/**
+
+jobs:
+  build-production:
+    runs-on: ubuntu-24.04
+    if: github.ref_name == github.event.repository.default_branch
+    name: Build and push production image
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.2.2
+
+      - name: Build and push image to single-region registry
+        uses: getsentry/action-build-and-push-images@b172ab61a5f7eabd58bd42ce231b517e79947c01
+        with:
+          image_name: 'reload'
+          platforms: linux/amd64
+          dockerfile_path: './Dockerfile'
+          ghcr: false
+          google_ar: true
+          tag_nightly: false
+          tag_latest: true
+          google_ar_image_name: us-central1-docker.pkg.dev/sentryio/reload/image
+          google_workload_identity_provider: projects/868781662168/locations/global/workloadIdentityPools/prod-github/providers/github-oidc-pool
+          google_service_account: gha-gcr-push@sac-prod-sa.iam.gserviceaccount.com
+
+      - name: Build and push image to multi-region registry
+        uses: getsentry/action-build-and-push-images@b172ab61a5f7eabd58bd42ce231b517e79947c01
+        with:
+          image_name: 'reload'
+          platforms: linux/amd64
+          dockerfile_path: './Dockerfile'
+          ghcr: false
+          google_ar: true
+          tag_nightly: false
+          tag_latest: true
+          google_ar_image_name: us-docker.pkg.dev/sentryio/reload-mr/image
+          google_workload_identity_provider: projects/868781662168/locations/global/workloadIdentityPools/prod-github/providers/github-oidc-pool
+          google_service_account: gha-gcr-push@sac-prod-sa.iam.gserviceaccount.com


### PR DESCRIPTION
Build the reload production image in GitHub Actions instead of Cloud Build.

Cloud Build cannot unpack the `dhi-mirror` (Docker Hardened Image) base layers and fails with `archive/tar: invalid tar header`. This builds the image with BuildKit via `getsentry/action-build-and-push-images` — the same path vroom/snuba/release-registry already took.

The action tags with the full `github.sha`, which is exactly what GoCD deploys by (`GO_REVISION_RELOAD_REPO`), and pushes to both registries:
- `us-central1-docker.pkg.dev/sentryio/reload/image` (single-region, what GoCD deploys from today)
- `us-docker.pkg.dev/sentryio/reload-mr/image` (multi-region mirror)

Auth uses the `gha-gcr-push` service account via Workload Identity Federation, authorized in getsentry/security-as-code#3128 (merged + applied).

This intentionally lands **while Cloud Build is still authoritative** so the new build can be verified in parallel — GoCD still gates on the Cloud Build check until the follow-up PR switches it over. After merge, confirm the workflow pushes `…/reload/image:<sha>` and `…/reload-mr/image:<sha>` before merging the GoCD gate flip.